### PR TITLE
docs: added missing step before heartbeat part in ex[#3]

### DIFF
--- a/exercises/non-retryable-error-types/README.md
+++ b/exercises/non-retryable-error-types/README.md
@@ -145,6 +145,7 @@ be updated to reflect this.
 7. Delete the return statement at the end of the Workflow, as the uncommented
    code will now make this statement unreachable.
 8. Save the file.
+9. Update `Starter.java` file to have a valid test card number - "4242424242424242", otherwise the validation would still be failing.
 
 ## Part D: Add a Heartbeat Timeout
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Readme file was updated for Non-retryable-error exercise, Part C. The original Starter.java file has wrong card number which fails validation as expected for Parts A and B. But for the Part C we need the workflow to progress past that point, so we need to fix the card number before proceeding.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
